### PR TITLE
fix negate_iife   : false

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     join_vars     : true,
     cascade       : true,
     side_effects  : true,
-    negate_iife   : true,
+    negate_iife   : false,
     screw_ie8     : false,
 
     warnings      : true,


### PR DESCRIPTION
Defaults will scramble [IIFEs & program completion values](https://github.com/mishoo/UglifyJS2/issues/543), which affect the majority JS I feed into this tool. (eg any jQuery plugs)
