### PR TITLE
Automatically update and publish to GitHub pages using GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: update
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+
+    if: github.actor == github.repository_owner
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@main
+    - name: update
+      run: bash build/update.sh
+    # Deploy the site
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: public
+        force_orphan: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,26 @@
-name: update
+name: GitHub Pages
 
 on:
   workflow_dispatch:
-  repository_dispatch:
 
 jobs:
-  build:
+  deploy:
 
     if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@main
-    - name: update
-      run: bash build/update.sh
-    # Deploy the site
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: public
-        force_orphan: true
+      - uses: actions/checkout@main
+      - name: update
+        run: bash build/update.sh
+      # Deploy the site
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: public
+          force_orphan: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "uglify"]
-	path = uglify
-	url = https://github.com/mishoo/UglifyJS2.git

--- a/build/update.sh
+++ b/build/update.sh
@@ -44,14 +44,9 @@ fi
 
 # Update version
 sed -i 's/\(<code id="version">\)[^<]*\(<\/code>\)/\1uglify-js '"$VERSION"'\2/' index.html
-CDN="//registry.npmmirror.com/uglify-js/$VERSION/files"
-CDN="${CDN//\//\\\/}"
-sed -i 's/\(<script src="\)uglify/\1'"$CDN"'/gI' index.html
-
-rm -rf uglify
 
 
 # Publish
 mkdir public
-cp favicon.ico index.html script.js style.css public
+cp -r favicon.ico index.html script.js style.css uglify public
 echo "Update to uglify-js $VERSION"


### PR DESCRIPTION
Hello, I have upgraded uglify-es to uglify-js, and added the feature of using GitHub actions to automatically update and publish to GitHub pages. 

Here are the specific changes:
- Add GitHub actions to publish on GitHub pages;
- Change uglify-es to uglify-js;
- When building, download uglify-js from GitHub releases instead of git;
- When publishing, use CDN(`registry.npmmirror.com`) instead of local files for uglify-js;

Update steps:
1. On the GitHub actions page, manually run workflow `update` to build and publish to the gh-pages branch;
2. Let GitHub pages use gh-pages branch;

![image](https://github.com/user-attachments/assets/892d2b99-104c-41f0-8cbd-0b059592a227)
![image](https://github.com/user-attachments/assets/2a8e9ae9-4911-4023-a111-6f42795a7fc5)
